### PR TITLE
TRIVIAL: temporarily remove engines from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,6 @@
   "description": "SPA for previewing instagram profile",
   "author": "Ivan Voronin",
   "license": "Apache-2.0",
-  "engineStrict": true,
-  "engines": {
-    "node": "10.18.1"
-  },
   "scripts": {
     "start": "webpack-dev-server --open --config webpack/dev.js",
     "build": "NODE_ENV=production webpack --config webpack/prod.js",


### PR DESCRIPTION
bc gh-action for size-limit can't work with 2 diffirent versions
https://github.com/voronin-ivan/instant-preview/pull/44/checks?check_run_id=2555153071

need for updating node-version