### PR TITLE
TRIVIAL: remove production deploy from gh-actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,6 @@ jobs:
         uses: nwtgck/actions-netlify@v1.1
         with:
           publish-dir: './build'
-          production-branch: master
-          production-deploy: ${{ github.ref == 'refs/heads/main' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           github-deployment-environment: Netlify
           deploy-message: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
The reason: to avoid running e2e-tests in production. Production deploy will be automatically evoked from Netlify-panel (only for master branch)